### PR TITLE
Add linting to continuous integration

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,32 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+    branches: [main, master]
+
+name: lint
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::lintr, local::.
+          needs: lint
+
+      - name: Lint
+        run: lintr::lint_package()
+        shell: Rscript {0}
+        env:
+          LINTR_ERROR_ON_LINT: true

--- a/.lintr
+++ b/.lintr
@@ -1,0 +1,5 @@
+linters: linters_with_defaults(
+  object_usage_linter(NULL))
+exclude: "# nolint"
+exclude_start: "# Begin Exclude Linting"
+exclude_end: "# End Exclude Linting"

--- a/R/average_wait.R
+++ b/R/average_wait.R
@@ -1,22 +1,28 @@
 #' @title Average Waiting Time
 #'
-#' @description This calculates the target mean wait given the two inputs of target_wait and a numerical value for factor
-#' The average wait is actually the target mean wait and is calculated as follows: target_wait / factor
-#' If we want to have a chance between 1.8%-0.2% of making a waiting time target, then the average patient should
-#' have a waiting time between a quarter and a sixth of the target. Therefore:
-#' The mean wait should sit somewhere between target_wait/factor=6 < Average Waiting Time < target_wait/factor=4
+#' @description This calculates the target mean wait given the two inputs of
+#'   target_wait and a numerical value for factor. The average wait is actually
+#'   the target mean wait and is calculated as follows: target_wait / factor. If
+#'   we want to have a chance between 1.8%-0.2% of making a waiting time target,
+#'   then the average patient should have a waiting time between a quarter and a
+#'   sixth of the target. Therefore: The mean wait should sit somewhere between
+#'   target_wait/factor=6 < Average Waiting Time < target_wait/factor=4.
 #'
-#' @param target_wait Numeric value of the number of weeks that has been set as the target within which the patient should be seen.
-#' @param factor  Numeric factor used in average wait calculation - to get a quarter of the target use factor=4 and one sixth of the target use factor = 6 etc. Defaults to 4.
+#' @param target_wait Numeric value of the number of weeks that has been set as
+#'   the target within which the patient should be seen.
+#' @param factor  Numeric factor used in average wait calculation - to get a
+#'   quarter of the target use factor=4 and one sixth of the target use factor =
+#'   6 etc. Defaults to 4.
 #'
-#' @return Numeric value of target mean waiting time to achieve a given target wait.
+#' @return Numeric value of target mean waiting time to achieve a given target
+#'   wait.
+#'
 #' @export
 #'
-#' @examples 
-#' # If the target wait is 52 weeks then the target mean wait with a factor of 4 would be 13
-#' # weeks and with a factor of 6 it would be 8.67 weeks.
+#' @examples
+#' # If the target wait is 52 weeks then the target mean wait with a factor of 4
+#' # would be 13 weeks and with a factor of 6 it would be 8.67 weeks.
 #' average_wait(52, 4)
-#'
 average_wait <- function(target_wait, factor = 4) {
   target_mean_wait <- target_wait / factor
   return(target_mean_wait)

--- a/R/queue_load.R
+++ b/R/queue_load.R
@@ -1,25 +1,25 @@
-#' @title Queue Load
+#' @title Calculate Queue Load
 #'
-#' @description
-#' Calculates the queue load. The queue load is the number of arrivals that occur for every patient leaving the queue (given that the
-#' waiting list did not empty).
-#' It could also be described as the rate of service at the queue.
-#' The queue load is calculated by dividing the demand by the capacity:
-#' queue_load = demand / capacity
+#' @description Calculates the queue load. The queue load is the number of
+#'   arrivals that occur for every patient leaving the queue (given that the
+#'   waiting list did not empty). It could also be described as the rate of
+#'   service at the queue. The queue load is calculated by dividing the demand
+#'   by the capacity: queue_load = demand / capacity.
 #'
-#' @param demand Numeric value of rate of demand in same units as target wait - e.g. if target wait is weeks, then demand in units of patients/week.
-#' @param capacity Numeric value of the number of patients that can be served (removals) from the waiting list each week.
+#' @param demand Numeric value of rate of demand in same units as target wait -
+#'   e.g. if target wait is weeks, then demand in units of patients/week.
+#' @param capacity Numeric value of the number of patients that can be served
+#'   (removals) from the waiting list each week.
 #'
-#' @return Numeric value of load which is the ratio between demand and capacity
+#' @return Numeric value of load which is the ratio between demand and capacity.
+#'
 #' @export
 #'
-#' @examples 
-#' # If 30 patients are added to the waiting list each week (demand) and 27 removed (capacity)
-#' # this results in a queue load of 1.11 (30/27)
+#' @examples
+#' # If 30 patients are added to the waiting list each week (demand) and 27
+#' removed (capacity) this results in a queue load of 1.11 (30/27).
 #' queue_load(30,27)
-#'
-#'
 queue_load <- function(demand, capacity) {
   load <- demand / capacity
-  return (load)
+  return(load)
 }

--- a/R/relief_capacity.R
+++ b/R/relief_capacity.R
@@ -1,29 +1,35 @@
-#' @title Relief Capacity
+#' @title Calculate Relief Capacity
 #'
-#' @description
-#' Calculates required relief capacity to achieve target queue size in a given period of time as a function of demand, queue size, target queue size and time period.
+#' @description Calculates required relief capacity to achieve target queue size
+#'   in a given period of time as a function of demand, queue size, target queue
+#'   size and time period.
 #'
-#' Relief Capacity is required if Queue Size > 2 * Target Queue Size.
+#'   Relief Capacity is required if Queue Size > 2 * Target Queue Size.
 #'
-#' Relief Capacity = Current Demand + (Queue Size - Target Queue Size)/Time Steps
+#'   Relief Capacity = Current Demand + (Queue Size - Target Queue Size) / Time
+#'   Steps.
 #'
-#' @param demand Numeric value of rate of demand in same units as target wait - e.g. if target wait is weeks, then demand in units of patients/week.
+#' @param demand Numeric value of rate of demand in same units as target wait -
+#'   e.g. if target wait is weeks, then demand in units of patients/week.
 #' @param queue_size Numeric value of  current number of patients in queue.
-#' @param target_queue_size Numeric value of desired number of patients in queue.
-#' @param weeks_to_target Numeric value of desired number of time-steps to reach the target queue size by.
+#' @param target_queue_size Numeric value of desired number of patients in
+#'   queue.
+#' @param weeks_to_target Numeric value of desired number of time-steps to reach
+#'   the target queue size by.
 #'
-#' @return A numeric value of the required rate of capacity to achieve a target queue size in a given period of time.
+#' @return A numeric value of the required rate of capacity to achieve a target
+#'   queue size in a given period of time.
+#'
 #' @export
 #'
 #' @examples
 #' # If demand is 30 patients per week, the current queue size is 1200 and the
 #' # target is to achieve a queue size of 390 in 26 weeks, then
-#'
-#' # Relief Capacity = 30 + (1200 - 390)/26 = 61.15 patients per week.
+#' # Relief Capacity = 30 + (1200 - 390) / 26 = 61.15 patients per week.
 #'
 #' relief_capacity(30, 1200, 390, 26)
-#'
-relief_capacity <- function(demand, queue_size, target_queue_size, weeks_to_target) {
-  rel_cap <- demand + (queue_size  -  target_queue_size) / weeks_to_target
+relief_capacity <- function(
+    demand, queue_size, target_queue_size, weeks_to_target) {
+  rel_cap <- demand + (queue_size - target_queue_size) / weeks_to_target
   return(rel_cap)
 }

--- a/R/target_capacity.R
+++ b/R/target_capacity.R
@@ -1,26 +1,30 @@
-#' @title Target Capacity
+#' @title Calculate Target Capacity
 #'
-#' @description
-#' Calculates the target capacity to achieve a given target waiting time as a function of observed demand, target waiting time and a variability coefficient F.
-#' 
-#' Target Capacity = Demand + 2 * ( 1 + 4 * F ) / Target Wait
-#' F defaults to 1.
+#' @description Calculates the target capacity to achieve a given target waiting
+#' time as a function of observed demand, target waiting time and a variability
+#' coefficient F.
 #'
-#' @param demand Numeric value of rate of demand in same units as target wait - e.g. if target wait is weeks, then demand in units of patients/week.
-#' @param target_wait Numeric value of number of weeks that has been set as the target within which the patient should be seen.
-#' @param F Variability coefficient, F = V/C * (D/C)^2 where C is the current number of operations per week; V is the current variance in the number of operations per week; D is the observed demand. Defaults to 1.
+#' Target Capacity = Demand + 2 * ( 1 + 4 * F ) / Target Wait F defaults to 1.
 #'
-#' @return A numeric value of target capacity required to achieve a target waiting time.
+#' @param demand Numeric value of rate of demand in same units as target wait -
+#'   e.g. if target wait is weeks, then demand in units of patients/week.
+#' @param target_wait Numeric value of number of weeks that has been set as the
+#'   target within which the patient should be seen.
+#' @param F Variability coefficient, F = V/C * (D/C)^2 where C is the current
+#'   number of operations per week; V is the current variance in the number of
+#'   operations per week; D is the observed demand. Defaults to 1.
+#'
+#' @return A numeric value of target capacity required to achieve a target
+#'   waiting time.
+#'
 #' @export
 #'
 #' @examples
 #'
-#' # If the target wait is 52 weeks, demand is 30 patients per week and F = 3 then
-#' # Target capacity = 30 + 2*(1+4*3)/52 = 30.5 patients per week.
-#'
+#' # If the target wait is 52 weeks, demand is 30 patients per week and F = 3
+#' # then Target capacity = 30 + 2 * (1 + 4 * 3)/52 = 30.5 patients per week.
 #' target_capacity(30,52,3)
-#'
 target_capacity <- function(demand, target_wait, F = 1) {
-  target_cap <- demand +  2 * ( 1 + 4 * F ) / target_wait
+  target_cap <- demand +  2 * (1 + 4 * F) / target_wait
   return(target_cap)
 }

--- a/R/target_queue_size.R
+++ b/R/target_queue_size.R
@@ -1,29 +1,32 @@
-#' @title Target Queue Size
+#' @title Calculate Target Queue Size
 #'
-#' @description
-#' Uses Little's Law to calculate the target queue size to achieve a target waiting time as a function of observed demand, target wait and a variability factor used in the target mean waiting time calculation.
-#' 
-#' Target Queue Size = Demand * Target Wait / 4.
+#' @description Uses Little's Law to calculate the target queue size to achieve
+#'   a target waiting time as a function of observed demand, target wait and a
+#'   variability factor used in the target mean waiting time calculation.
 #'
-#' The average wait should sit somewhere between 
-#' target_wait/factor=6 < Average Waiting Time < target_wait/factor=4
-#' The factor defaults to 4.
-#' 
-#' Only applicable when Capacity > Demand.
+#'   Target Queue Size = Demand * Target Wait / 4.
 #'
-#' @param demand Numeric value of rate of demand in same units as target wait - e.g. if target wait is weeks, then demand in units of patients/week.
-#' @param target_wait Numeric value of number of weeks that has been set as the target within which the patient should be seen.
-#' @param factor Numeric factor used in average wait calculation - to get a quarter of the target use factor=4 and one sixth of the target use factor = 6 etc. Defaults to 4.
+#'   The average wait should sit somewhere between target_wait/factor=6 <
+#'   Average Waiting Time < target_wait/factor=4 The factor defaults to 4.
+#'
+#'   Only applicable when Capacity > Demand.
+#'
+#' @param demand Numeric value of rate of demand in same units as target wait -
+#'   e.g. if target wait is weeks, then demand in units of patients/week.
+#' @param target_wait Numeric value of number of weeks that has been set as the
+#'   target within which the patient should be seen.
+#' @param factor Numeric factor used in average wait calculation - to get a
+#'   quarter of the target use factor=4 and one sixth of the target use factor =
+#'   6 etc. Defaults to 4.
 #'
 #' @return Numeric target queue length.
+#'
 #' @export
 #'
 #' @examples
-#' # If demand  is 30 patients per week and the target wait is 52 weeks, then the 
-#' # Target queue size = 30 * 52/4 = 390 patients.
-#'
-#' target_queue_size(30,52,4)
-#' 
+#' # If demand is 30 patients per week and the target wait is 52 weeks, then the
+#' # Target queue size = 30 * 52 / 4 = 390 patients.
+#' target_queue_size(30, 52, 4)
 target_queue_size <- function(demand, target_wait, factor = 4) {
   mean_wait <- average_wait(target_wait, factor)
   target_queue_length <- demand * mean_wait

--- a/R/waiting_list_pressure.R
+++ b/R/waiting_list_pressure.R
@@ -1,21 +1,23 @@
-#' @title Calculate the waiting list pressure
+#' @title Calculate Waiting List Pressure
 #'
-#' @description For a waiting list with target waiting time, the pressure on the waiting list is twice
-#'  the mean delay divided by the waiting list target.
-#'  The pressure of any given waiting list should be less than 1.
-#'  If the pressure is greater than 1 then the waiting list is most likely going to miss its target.
-#'  The waiting list pressure is calculated as follows:
-#'  pressure = 2 x mean_wait / target_wait
+#' @description For a waiting list with target waiting time, the pressure on the
+#'   waiting list is twice the mean delay divided by the waiting list target.
+#'   The pressure of any given waiting list should be less than 1. If the
+#'   pressure is greater than 1 then the waiting list is most likely going to
+#'   miss its target. The waiting list pressure is calculated as follows:
+#'   pressure = 2 * mean_wait / target_wait.
 #'
-#' @param mean_wait Numeric value of target mean waiting time to achieve a given target wait
-#' @param target_wait Numeric value of the number of weeks that has been set as the target within which the patient should be seen
+#' @param mean_wait Numeric value of target mean waiting time to achieve a given
+#'   target wait.
+#' @param target_wait Numeric value of the number of weeks that has been set as
+#'   the target within which the patient should be seen.
 #'
-#' @return Numeric value of wait_pressure which is the waiting list pressure
+#' @return Numeric value of wait_pressure which is the waiting list pressure.
+#'
 #' @export
 #'
 #' @examples
-#' waiting_list_pressure(63,52)
-#'
+#' waiting_list_pressure(63, 52)
 waiting_list_pressure <- function(mean_wait, target_wait) {
   wait_pressure <- 2 * mean_wait / target_wait
   return(wait_pressure)

--- a/tests/testthat/test-average_wait.R
+++ b/tests/testthat/test-average_wait.R
@@ -19,9 +19,9 @@
 #   expect_error(target_wait(in1, in2), em)
 # })
 
-test_that("it returns an expected result with fixed single values, against arithmetic", {
+test_that("it returns expected result with fixed single values vs arithmetic", {
   em <- "average_wait(): arithmetic error with single value inputs."
-  expect_equal(average_wait(52, 4), 52/4)
+  expect_equal(average_wait(52, 4), 52 / 4)
 })
 
 test_that("it returns an expected result with fixed single values", {
@@ -36,19 +36,17 @@ test_that("it returns an expected result with vector of fixed values", {
   expect_equal(
     average_wait(
       c(35, 30, 52),
-      c(4,4,6)
-    )
-    , c(8.75, 7.5, 8.6666667)
+      c(4, 4, 6)
+    ),
+    c(8.75, 7.5, 8.6666667)
   )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
   in2 <- rnorm(n = n, 4, 2)
   em <- "target_queue_size(): output vector length != input vector length."
   expect_length(average_wait(in1, in2), length(in1))
 })
-
-

--- a/tests/testthat/test-queue_load.R
+++ b/tests/testthat/test-queue_load.R
@@ -19,9 +19,9 @@
 #   expect_error(queue_load(in1, in2), em)
 # })
 
-test_that("it returns an expected result with fixed single values, against arithmetic", {
+test_that("it returns expected result with fixed single values vs arithmetic", {
   em <- "queue_load(): arithmetic error with single value inputs."
-  expect_equal(queue_load(30, 27), 30/27)
+  expect_equal(queue_load(30, 27), 30 / 27)
 })
 
 test_that("it returns an expected result with fixed single values", {
@@ -35,19 +35,17 @@ test_that("it returns an expected result with vector of fixed values", {
   expect_equal(
     queue_load(
       c(35, 30, 52),
-      c(27,25,42)
-    )
-    , c( 1.2962963, 1.2, 1.23809524)
+      c(27, 25, 42)
+    ),
+    c(1.2962963, 1.2, 1.23809524)
   )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
   in2 <- rnorm(n = n, 30, 5)
   em <- "target_queue_size(): output vector length != input vector length."
   expect_length(queue_load(in1, in2), length(in1))
 })
-
-

--- a/tests/testthat/test-relief_capacity.R
+++ b/tests/testthat/test-relief_capacity.R
@@ -29,9 +29,9 @@
 # })
 #'
 
-test_that("it returns an expected result with fixed single values, against arithmetic", {
+test_that("it returns expected result with fixed single values vs arithmetic", {
   em <- "relief_capacity(): arithmetic error with single value inputs."
-  expect_equal(relief_capacity(30, 1200, 390, 26), 30 + (1200 - 390)/26)
+  expect_equal(relief_capacity(30, 1200, 390, 26), 30 + (1200 - 390) / 26)
 })
 
 test_that("it returns an expected result with fixed single values", {
@@ -43,25 +43,23 @@ test_that("it returns an expected result with vector of fixed values", {
   em <- "relief_capacity(): arithmetic error with vector of input values."
   expect_equal(
     relief_capacity(
-      c(30, 33, 35 ),
+      c(30, 33, 35),
       c(1200, 800, 250),
-      c(390,200,100),
+      c(390, 200, 100),
       c(26, 30, 15)
-      )
-    , c(61.153846, 53, 45)
-    )
+    ),
+    c(61.153846, 53, 45)
+  )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
-  in2 <- in1 * (15 * runif(1,0 ,1.5))
-  in3 <- in1 * (5 * runif(1,1 ,1.5))
-  in4 <- in1 * (runif(1,0.5,1.5))
+  in2 <- in1 * (15 * runif(1, 0, 1.5))
+  in3 <- in1 * (5 * runif(1, 1, 1.5))
+  in4 <- in1 * (runif(1, 0.5, 1.5))
 
   em <- "relief_capacity(): output vector length != input vector length."
   expect_length(relief_capacity(in1, in2, in3, in4), length(in1))
 })
-
-

--- a/tests/testthat/test-target_capacity.R
+++ b/tests/testthat/test-target_capacity.R
@@ -19,35 +19,33 @@
 #   expect_error(target_capacity(in1, in2), em)
 # })
 
-test_that("it returns an expected result with fixed single values, against arithmetic", {
+test_that("it returns expected result with fixed single values vs arithmetic", {
   em <- "target_capacity(): arithmetic error with single value inputs."
-  expect_equal(target_capacity(30,52,3), 30 + 2*(1+4*3)/52)
+  expect_equal(target_capacity(30, 52, 3), 30 + 2 * (1 + 4 * 3) / 52)
 })
 
 test_that("it returns an expected result with fixed single values", {
   em <- "target_capacity(): arithmetic error with single value inputs."
-  expect_equal(target_capacity(30,52,3), 30.5)
+  expect_equal(target_capacity(30, 52, 3), 30.5)
 })
 
 test_that("it returns an expected result with vector of fixed values", {
   em <- "target_capacity(): arithmetic error with vector of input values."
   expect_equal(
     target_capacity(
-      c(30, 42, 35 ),
+      c(30, 42, 35),
       c(52, 65, 50),
-      c(3,2,1)
-      )
-    , c(30.5, 42.276923, 35.2)
-    )
+      c(3, 2, 1)
+    ),
+    c(30.5, 42.276923, 35.2)
+  )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
-  in2 <- in1 * runif(1,0.5,1.5)
+  in2 <- in1 * runif(1, 0.5 ,1.5)
   em <- "target_capacity(): output vector length != input vector length."
   expect_length(target_capacity(in1, in2), length(in1))
 })
-
-

--- a/tests/testthat/test-target_queue_size.R
+++ b/tests/testthat/test-target_queue_size.R
@@ -30,21 +30,19 @@ test_that("it returns an expected result with vector of fixed values", {
   em <- "target_queue_size(): arithmetic error with vector of values as inputs."
   expect_equal(
     target_queue_size(
-      c(30, 30, 30 ),
+      c(30, 30, 30),
       c(52, 50, 50),
-      c(4,4,6)
-    )
-    , c(390, 375, 250)
+      c(4, 4, 6)
+    ),
+    c(390, 375, 250)
   )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
-  in2 <- in1 * (1.2 + runif(1,0,1.5))
+  in2 <- in1 * (1.2 + runif(1, 0, 1.5))
   em <- "target_queue_size(): output vector length != input vector length."
   expect_length(target_queue_size(in1, in2), length(in1))
 })
-
-

--- a/tests/testthat/test-waiting_list_pressure.R
+++ b/tests/testthat/test-waiting_list_pressure.R
@@ -18,7 +18,7 @@
 #   expect_error(waiting_list_pressure(in1, in2), em)
 # })
 
-test_that("it returns an expected result with fixed single values, against arithmetic", {
+test_that("it returns expected result with fixed single values vs arithmetic", {
   em <- "waiting_list_pressure(): arithmetic error with single value inputs."
   expect_equal(waiting_list_pressure(63, 52), 2 * 63 / 52)
 })
@@ -32,20 +32,18 @@ test_that("it returns an expected result with vector of fixed values", {
   em <- "waiting_list_pressure(): arithmetic error with vector of input values."
   expect_equal(
     waiting_list_pressure(
-      c(63, 42, 55 ),
+      c(63, 42, 55),
       c(52, 24, 50)
-      )
-    , c(2.42307692, 3.5, 2.2)
-    )
+    ),
+    c(2.42307692, 3.5, 2.2)
+  )
 })
 
 
 test_that("it returns the same length output as provided on input", {
-  n <- round(runif(1, 0,30))
+  n <- round(runif(1, 0, 30))
   in1 <- rnorm(n = n, 50, 20)
-  in2 <- in1 * (1.2 + runif(1,0,1.5))
+  in2 <- in1 * (1.2 + runif(1, 0, 1.5))
   em <- "waiting_list_pressure(): output vector length != input vector length."
   expect_length(waiting_list_pressure(in1, in2), length(in1))
 })
-
-

--- a/vignettes/example_walkthrough.Rmd
+++ b/vignettes/example_walkthrough.Rmd
@@ -50,7 +50,7 @@ demand <- 30
 capacity <- 27
 
 # Standard deviation of number of operations per week
-std_dev_procedures <- 160  
+std_dev_procedures <- 160
 
 ```
 
@@ -118,9 +118,9 @@ If the waiting list size is over twice the target queue size, then we consider t
 weeks_until_target_acheived <- 26
 
 relief_capacity <- relief_capacity(
-  demand = demand, 
-  queue_size = queue_size, 
-  target_queue_size = target_queue_size, 
+  demand = demand,
+  queue_size = queue_size,
+  target_queue_size = target_queue_size,
   weeks_to_target = weeks_until_target_acheived
 )
 relief_capacity
@@ -151,9 +151,10 @@ Higher values represent more variability, which in turn will increase the capaci
 f_1 <- 1
 
 target_capacity_1 <- target_capacity(
-  demand = demand, 
+  demand = demand,
   target_wait = waiting_time_target,
-  F = f_1)
+  F = f_1
+)
 target_capacity_1
 ```
 
@@ -163,9 +164,10 @@ If F is `r f_1`, we can see that the capacity required is `r round(target_capaci
 f_2 <- 6.58
 
 target_capacity_2 <- target_capacity(
-  demand = demand, 
-  target_wait = waiting_time_target, 
-  F = f_2)
+  demand = demand,
+  target_wait = waiting_time_target,
+  F = f_2
+)
 target_capacity_2
 ```
 
@@ -188,7 +190,10 @@ Measuring waiting list pressure can give a comparative measure with which to com
 For the P4 ENT example we have been following:
 
 ```{r}
-waiting_list_pressure_p4 <- waiting_list_pressure(avg_waiting_time, waiting_time_target)
+waiting_list_pressure_p4 <- waiting_list_pressure(
+  avg_waiting_time,
+  waiting_time_target
+)
 waiting_list_pressure_p4
 ```
 
@@ -204,7 +209,10 @@ queue_size_p2 <- 220
 avg_waiting_time_p2 <- 24
 waiting_time_target_p2 <- 4
 
-waiting_list_pressure_p2 <- waiting_list_pressure(avg_waiting_time_p2, waiting_time_target_p2)
+waiting_list_pressure_p2 <- waiting_list_pressure(
+  avg_waiting_time_p2,
+  waiting_time_target_p2
+)
 waiting_list_pressure_p2
 ```
 


### PR DESCRIPTION
Close #8. Note that:

* this is vanilla linting with [{lintr}](https://lintr.r-lib.org/), but I've added a `.lintr` file where we can set or override defaults as needed
* I've deactivated the object-usage linter in the `.lintr` file because it gave a false positive for a function name that's actually part of the package
* I've fixed all the lint failures as far as I can (and kept these in line with the tidyverse style guide if needed), though some are still outstanding:
    - we have an argument called `F` (fails the object-name and T-and-F linters)
    - many test files have commented-out code awaiting some input error handling (see #28)