### PR TITLE
move ggplot2 to from imports to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,16 +24,15 @@ Config/testthat/edition: 3
 Imports: 
     cli,
     dplyr,
-    ggplot2,
     rlang,
     purrr,
     utils,
     stats
 Suggests: 
+    ggplot2,
     knitr,
     rmarkdown,
     testthat (>= 3.0.0)
 Depends: 
     R (>= 2.10)
 LazyData: true
-


### PR DESCRIPTION
closes #82 

ggplot2 is currently only used in vignettes, so only needs to be in the package "suggests", and is not needed as a package "import".