### PR TITLE
add all contributors file to Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,5 @@ cran-comments.md
 .lintr
 ^data-raw$
 
+^README\.Rmd$
+.all-contributorsrc


### PR DESCRIPTION
closes #85 

Simply adds a file to .Rbuildignore to prevent R SMD check from creating a "note".