### PR TITLE
Add column specification to function return documentation

### DIFF
--- a/R/create_waiting_list.R
+++ b/R/create_waiting_list.R
@@ -17,8 +17,24 @@
 #' as ROTT. Defaults to 0.
 #' @param ... Container for the list
 #'
-#' @return A tibble of a random generated list of patients with addition_date,
-#'  removal_date, wait_length and rott status for each patient
+#' @return A tibble with randomly generated patient records and the following
+#'   columns:
+#'
+#' \describe{
+#'   \item{pat_id}{Integer. Unique identifier for the patient.}
+#'   \item{addition_date}{Date. The date the patient was added to the waiting
+#'     list.}
+#'   \item{removal_date}{Date. The date the patient was removed from the
+#'     waiting list.}
+#'   \item{wait_length}{Numeric. Number of days between the addition and
+#'     removal dates.}
+#'   \item{rott}{Logical. Whether the removal was for
+#'     reasons other than treatment (ROTT).}
+#' }
+#' Additional columns may be included if supplied via \code{...},
+#'   where named vectors (e.g., patient-level variables) of compatible length
+#'   are merged into the output tibble.
+#'
 #' @export
 #'
 #' @examples create_waiting_list(366, 50, 21, "2024-01-01", 10, 0.1)

--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -5,7 +5,32 @@
 #' @param n_rows Number of rows/patients to generate
 #' @param start_date Start date (needed to generate patient ages)
 #'
-#' @return data.frame. Empty waiting list.
+#'@return A data.frame representing an empty waiting list with the following columns:
+#'
+#' \describe{
+#'   \item{Referral}{Logical. Referral date; all values are \code{NA}.}
+#'   \item{Removal}{Date. Removal date; all values are \code{NA}.}
+#'   \item{Withdrawal}{Logical. Indicates if the patient withdrew before
+#'     treatment; all values are \code{NA}.}
+#'   \item{Priority}{Numeric. Generated Waiting list priority level,
+#'     from 1 (most urgent) to 4 (least urgent).}
+#'   \item{Target_wait}{Numeric. Target number of days the patient should wait
+#'     at the assigned priority level e.g. 28 at priority 2.}
+#'   \item{Name}{Character. Randomly generated patient name in the format
+#'     \code{"Last, First"}.}
+#'   \item{Birth_Date}{Date. Generated patient date of birth, using a
+#'     semi-realistic age distribution.}
+#'   \item{NHS_number}{Integer. Generated patient number up to 1,000,000.}
+#'   \item{Specialty_code}{Character. One-digit code for the specialty of the
+#'     selected procedure.}
+#'   \item{Specialty}{Character. Name of the specialty for the selected
+#'     procedure.}
+#'   \item{OPCS}{Character. OPCS-4 code of the randomly selected procedure.}
+#'   \item{Proceedure}{Character. Name of the randomly selected procedure.}
+#'   \item{Consultant}{Character. Randomly generated consultant name in the
+#'     format \code{"Last, First"}.}
+#' }
+#'
 #' @export sim_patients
 #' @import randomNames
 #' @examples

--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -10,26 +10,25 @@
 #' \describe{
 #'   \item{Referral}{Logical. Referral date; all values are \code{NA}.}
 #'   \item{Removal}{Date. Removal date; all values are \code{NA}.}
-#'   \item{Withdrawal}{Logical. Indicates if the patient withdrew before
-#'     treatment; all values are \code{NA}.}
-#'   \item{Priority}{Numeric. Generated Waiting list priority level,
-#'     from 1 (most urgent) to 4 (least urgent).}
-#'   \item{Target_wait}{Numeric. Target number of days the patient should wait
-#'     at the assigned priority level e.g. 28 at priority 2.}
-#'   \item{Name}{Character. Randomly generated patient name in the format
+#'   \item{Withdrawal}{Logical. Patient withdrawal date; all values are
+#'     \code{NA}}
+#'   \item{Priority}{Numeric. Waiting list priority level, from 1
+#'     (most urgent) to 4 (least urgent).}
+#'   \item{Target_wait}{Numeric. Target number of days the patient should
+#'     wait at the assigned priority level (e.g., 28 days for priority 2)}
+#'   \item{Name}{Character. Patient name in the format
 #'     \code{"Last, First"}.}
-#'   \item{Birth_Date}{Date. Generated patient date of birth, using a
-#'     semi-realistic age distribution.}
-#'   \item{NHS_number}{Integer. Generated patient number up to 1,000,000.}
-#'   \item{Specialty_code}{Character. One-digit code for the specialty of the
-#'     selected procedure.}
-#'   \item{Specialty}{Character. Name of the specialty for the selected
-#'     procedure.}
-#'   \item{OPCS}{Character. OPCS-4 code of the randomly selected procedure.}
-#'   \item{Proceedure}{Character. Name of the randomly selected procedure.}
-#'   \item{Consultant}{Character. Randomly generated consultant name in the
-#'     format \code{"Last, First"}.}
-#' }
+#'   \item{Birth_Date}{Date. Date of birth.}
+#'   \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
+#'   \item{Specialty_code}{Character. One-letter code representing the
+#'     specialty of the procedure.}
+#'   \item{Specialty}{Character. Full name of the specialty associated with
+#'     the procedure.}
+#'   \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
+#'   \item{Proceedure}{Character. Name of the selected procedure.}
+#'   \item{Consultant}{Character. Consultant name in the format
+#'     \code{"Last, First"}.}
+#'  }
 #'
 #' @export sim_patients
 #' @import randomNames

--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -5,7 +5,8 @@
 #' @param n_rows Number of rows/patients to generate
 #' @param start_date Start date (needed to generate patient ages)
 #'
-#'@return A data.frame representing an empty waiting list with the following columns:
+#'@return A data.frame representing an empty waiting list with the
+#'  following columns:
 #'
 #' \describe{
 #'   \item{Referral}{Logical. Referral date; all values are \code{NA}.}

--- a/R/sim_schedule.R
+++ b/R/sim_schedule.R
@@ -6,7 +6,10 @@
 #' @param start_date Start date (needed to generate patient ages)
 #' @param daily_capacity Number of patients per day
 #'
-#' @return data.frame. Empty waiting list.
+#' @return A vector of \code{Date} values representing scheduled procedure
+#'   dates. The length of the vector is equal to \code{n_rows}, and the dates
+#'   are spaced according to the specified \code{daily_capacity}.
+#'
 #' @export sim_schedule
 #'
 

--- a/R/wl_insert.R
+++ b/R/wl_insert.R
@@ -8,7 +8,15 @@
 #' @param referral_index integer. The column number in the waiting_list which
 #'   contains the referral dates
 #'
-#' @return dataframe. A df of the updated waiting list
+#' @return A \code{data.frame} representing the updated waiting list
+#'   with additional referrals dates, with columns:
+#'
+#' \describe{
+#'   \item{referral}{Date. The updated referral dates, with new values from
+#'     \code{additions} appended to the existing data.}
+#'   \item{removal}{Date. The removal date for each patient. Newly added
+#'     rows have \code{NA} in this column.}
+#' }
 #' @export
 #'
 #' @examples

--- a/R/wl_join.R
+++ b/R/wl_join.R
@@ -7,7 +7,11 @@
 #' @param wl_2 a waiting list: dataframe consisting addition and removal dates
 #' @param referral_index the column index where referrals are listed
 #'
-#' @return updated_list a new waiting list
+#' @return A data.frame representing the combined waiting list, created by
+#'   joining \code{wl_1} and \code{wl_2}. The result is sorted by the referral
+#'   date column specified by \code{referral_index}. The column structure is
+#'   preserved from the input data frames.
+#'
 #' @export
 #'
 #' @examples

--- a/R/wl_queue_size.R
+++ b/R/wl_queue_size.R
@@ -15,8 +15,10 @@
 #'   the input data.frame. The returned data.frame has the following columns:
 #'
 #' \describe{
-#'   \item{dates}{Date. Each date within the computed range, starting from the first referral.}
-#'   \item{queue_size}{Numeric. Number of patients on the waiting list on that date.}
+#'   \item{dates}{Date. Each date within the computed range, starting from the
+#'     first referral.}
+#'   \item{queue_size}{Numeric. Number of patients on the waiting list
+#'     on that date.}
 #' }
 #' @export
 #'

--- a/R/wl_queue_size.R
+++ b/R/wl_queue_size.R
@@ -9,7 +9,15 @@
 #' @param referral_index the index of referrals in waiting_list
 #' @param removal_index the index of removals in waiting_list
 #'
-#' @return a list of dates and queue sizes
+#' @return A data.frame containing the size of the waiting list for each day in
+#'   the specified date range. If \code{start_date} and/or \code{end_date} are
+#'   \code{NULL}, the function uses the earliest and latest referral dates in
+#'   the input data.frame. The returned data.frame has the following columns:
+#'
+#' \describe{
+#'   \item{dates}{Date. Each date within the computed range, starting from the first referral.}
+#'   \item{queue_size}{Numeric. Number of patients on the waiting list on that date.}
+#' }
 #' @export
 #'
 #' @examples

--- a/R/wl_referral_stats.R
+++ b/R/wl_referral_stats.R
@@ -7,8 +7,16 @@
 #' @param end_date date. The end date to calculate to
 #' @param referral_index the column index of referrals
 #'
-#' @return data.frame. A df containing number of referrals, mean demand,
-#'   and the coefficient of variation of referrals
+#' @return A data.frame with the following summary statistics on
+#'   referrals/demand:
+#'
+#' \describe{
+#'   \item{demand_weekly}{Numeric. Mean number of additions to the waiting list per week.}
+#'   \item{demand_daily}{Numeric. Mean number of additions to the waiting list per day.}
+#'   \item{demand_cov}{Numeric. Coefficient of variation in the time between additions to the waiting list.}
+#'   \item{demand_count}{Numeric. Total demand over the full time period.}
+#' }
+#'
 #' @export
 #'
 #' @examples

--- a/R/wl_referral_stats.R
+++ b/R/wl_referral_stats.R
@@ -11,9 +11,12 @@
 #'   referrals/demand:
 #'
 #' \describe{
-#'   \item{demand_weekly}{Numeric. Mean number of additions to the waiting list per week.}
-#'   \item{demand_daily}{Numeric. Mean number of additions to the waiting list per day.}
-#'   \item{demand_cov}{Numeric. Coefficient of variation in the time between additions to the waiting list.}
+#'   \item{demand_weekly}{Numeric. Mean number of additions to the waiting list
+#'     per week.}
+#'   \item{demand_daily}{Numeric. Mean number of additions to the waiting list
+#'     per day.}
+#'   \item{demand_cov}{Numeric. Coefficient of variation in the time between
+#'     additions to the waiting list.}
 #'   \item{demand_count}{Numeric. Total demand over the full time period.}
 #' }
 #'

--- a/R/wl_removal_stats.R
+++ b/R/wl_removal_stats.R
@@ -8,8 +8,16 @@
 #' @param referral_index int. Index of the referral column in waiting_list.
 #' @param removal_index int. Index of the removal column in waiting_list.
 #'
-#' @return data.frame. A df containing number of removals, mean capacity,
-#'   and the coefficient of variation of removals
+#' @return A data.frame with the following summary statistics on
+#'   removals/capacity:
+#'
+#' \describe{
+#'   \item{capacity_weekly}{Numeric. Mean number of removals from the waiting list per week.}
+#'   \item{capacity_daily}{Numeric. Mean number of removals from the waiting list per day.}
+#'   \item{capacity_cov}{Numeric. Coefficient of variation in the time between removals from the waiting list.}
+#'   \item{removal_count}{Numeric. Total number of removals from the waiting list over the full time period.}
+#' }
+#'
 #' @export
 #'
 #' @examples

--- a/R/wl_removal_stats.R
+++ b/R/wl_removal_stats.R
@@ -12,10 +12,14 @@
 #'   removals/capacity:
 #'
 #' \describe{
-#'   \item{capacity_weekly}{Numeric. Mean number of removals from the waiting list per week.}
-#'   \item{capacity_daily}{Numeric. Mean number of removals from the waiting list per day.}
-#'   \item{capacity_cov}{Numeric. Coefficient of variation in the time between removals from the waiting list.}
-#'   \item{removal_count}{Numeric. Total number of removals from the waiting list over the full time period.}
+#'   \item{capacity_weekly}{Numeric. Mean number of removals from the waiting
+#'     list per week.}
+#'   \item{capacity_daily}{Numeric. Mean number of removals from the waiting
+#'     list per day.}
+#'   \item{capacity_cov}{Numeric. Coefficient of variation in the time between
+#'     removals from the waiting list.}
+#'   \item{removal_count}{Numeric. Total number of removals from the waiting
+#'     list over the full time period.}
 #' }
 #'
 #' @export

--- a/R/wl_schedule.R
+++ b/R/wl_schedule.R
@@ -16,8 +16,23 @@
 #' @param unscheduled logical.
 #'  If TRUE, returns a list of scheduled and unscheduled procedures
 #'  If FALSE, only returns the updated waiting list
-#' @return data.frame. A df of the updated waiting list with removal dates
-#'  added according to the schedule
+#'
+#' @return The updated waiting list with removal dates assigned based on
+#'   the given schedule, either as a single \code{data.frame} (default) or as
+#'   part of a list (if \code{unscheduled = TRUE}).
+#'
+#' If \code{unscheduled = TRUE}, returns a \code{list} with two data frames:
+#' 1. A \code{data.frame}. The updated waiting list with scheduled removals.
+#'
+#' 2. A \code{data.frame} showing which slots were used, with columns:
+#'
+#'    \describe{
+#'      \item{schedule}{Date. The available dates from the input
+#'        \code{schedule}.}
+#'      \item{scheduled}{Numeric. \code{1} if the slot was used to schedule a
+#'        patient, \code{0} if not.}
+#'    }
+#'
 #' @export
 #'
 #'

--- a/R/wl_simulator.R
+++ b/R/wl_simulator.R
@@ -11,8 +11,39 @@
 #' @param withdrawal_prob numeric. Probability of a patient withdrawing.
 #' @param detailed_sim logical. If TRUE, simulation provides detailed output.
 #'
+#' @return A \code{data.frame} simulating a waiting list, with columns:
 #'
-#' @return data.frame. A df of simulated referrals and removals
+#' \describe{
+#'   \item{Referral}{Date. The date each patient was added to the waiting list.}
+#'   \item{Removal}{Date. The date each patient was removed from the waiting
+#'     list (may be \code{NA} if unscheduled).}
+#'
+#'
+#'   \strong{If \code{detailed_sim = TRUE}}: returns a more detailed
+#'   \code{data.frame} with the following additional
+#'   fields:
+#'
+#'   \describe{
+#'       \item{Withdrawal}{Date. The date the patient withdrew from the
+#'         waiting list.}
+#'       \item{Priority}{Numeric. Waiting list priority level, from 1
+#'         (most urgent) to 4 (least urgent).}
+#'       \item{Target_wait}{Numeric. Target number of days the patient should
+#'         wait at the assigned priority level (e.g., 28 days for priority 2)}
+#'       \item{Name}{Character. Patient name in the format
+#'         \code{"Last, First"}.}
+#'       \item{Birth_Date}{Date. Date of birth.}
+#'       \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
+#'       \item{Specialty_code}{Character. One-letter code representing the
+#'         specialty of the procedure.}
+#'       \item{Specialty}{Character. Full name of the specialty associated with
+#'         the procedure.}
+#'       \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
+#'       \item{Proceedure}{Character. Name of the selected procedure.}
+#'       \item{Consultant}{Character. Consultant name in the format
+#'         \code{"Last, First"}.}
+#'   }
+#' }
 #'
 #' @import dplyr
 #' @importFrom stats rgeom

--- a/R/wl_stats.R
+++ b/R/wl_stats.R
@@ -7,7 +7,39 @@
 #' @param start_date date. The start date to calculate from
 #' @param end_date date. The end date to calculate to
 #'
-#' @return data.frame. A df of important waiting list statistics
+#' @return A data.frame of key waiting list summary statistics based on queueing
+#'   theory:
+#'
+#' \describe{
+#'   \item{mean_demand}{Numeric. Mean number of additions to the waiting list
+#'     per week.}
+#'   \item{mean_capacity}{Numeric. Mean number of removals from the waiting list
+#'     per week.}
+#'   \item{load}{Numeric. Ratio between demand and capacity.}
+#'   \item{load_too_big}{Logical. Whether the load is greater than or equal to 1
+#'     i.e. whether the waiting list is unstable and expected to grow.}
+#'   \item{count_demand}{Numeric. Total demand (i.e. referrals) over the full
+#'     time period.}
+#'   \item{queue_size}{Numeric. Number of patients on the waiting list at the
+#'     end of the time period.}
+#'   \item{target_queue_size}{Numeric. Size of waiting list required for the
+#'     average wait time to be a quarter of the \code{target_wait}.}
+#'   \item{queue_too_big}{Logical. Whether \code{queue_size} is more than twice
+#'     the \code{target_queue_size}.}
+#'   \item{mean_wait}{Numeric. Mean waiting time in weeks.}
+#'   \item{cv_arrival}{Numeric. Coefficient of variation in time between
+#'     additions to the waiting list.}
+#'   \item{cv_removal}{Numeric. Coefficient of variation in time between
+#'     removals from the waiting list.}
+#'   \item{target_capacity}{Numeric. The weekly capacity required to maintain
+#'     the waiting list at its target equilibrium, assuming the target queue
+#'       size has been reached.}
+#'   \item{relief_capacity}{Numeric. If \code{queue_too_big} is \code{TRUE},
+#'     the weekly capacity required to reduce the queue to the target size in
+#'     26 weeks. Otherwise \code{NA}.}
+#'   \item{pressure}{Numeric. A measure of pressure on the system, defined as
+#'     \code{2 × mean_wait / target_wait}.}
+#' }
 #'
 #' @export
 #'

--- a/R/wl_stats.R
+++ b/R/wl_stats.R
@@ -7,8 +7,8 @@
 #' @param start_date date. The start date to calculate from
 #' @param end_date date. The end date to calculate to
 #'
-#' @return A data.frame of key waiting list summary statistics based on queueing
-#'   theory:
+#' @return A data.frame of key waiting list summary statistics based on
+#'   queueing theory:
 #'
 #' \describe{
 #'   \item{mean_demand}{Numeric. Mean number of additions to the waiting list
@@ -16,29 +16,35 @@
 #'   \item{mean_capacity}{Numeric. Mean number of removals from the waiting list
 #'     per week.}
 #'   \item{load}{Numeric. Ratio between demand and capacity.}
-#'   \item{load_too_big}{Logical. Whether the load is greater than or equal to 1
-#'     i.e. whether the waiting list is unstable and expected to grow.}
-#'   \item{count_demand}{Numeric. Total demand (i.e. referrals) over the full
-#'     time period.}
+#'   \item{load_too_big}{Logical. Whether the load is greater than or equal to 1,
+#'     indicating whether the waiting list is unstable and expected to grow.}
+#'   \item{count_demand}{Numeric. Total demand (i.e., number of referrals) over
+#'     the full time period.}
 #'   \item{queue_size}{Numeric. Number of patients on the waiting list at the
 #'     end of the time period.}
-#'   \item{target_queue_size}{Numeric. Size of waiting list required for the
-#'     average wait time to be a quarter of the \code{target_wait}.}
+#'   \item{target_queue_size}{Numeric. The recommended size of the waiting list
+#'     to achieve approximately 98.2% of patients being treated within their
+#'     target wait time. This is based on Little’s Law, assuming the system
+#'     is in equilibrium, with the average waiting time set to one-quarter of
+#'     the \code{target_wait}.}
 #'   \item{queue_too_big}{Logical. Whether \code{queue_size} is more than twice
-#'     the \code{target_queue_size}.}
+#'     the \code{target_queue_size}. A value of \code{TRUE} indicates the queue
+#'     is at risk of missing its targets.}
 #'   \item{mean_wait}{Numeric. Mean waiting time in weeks.}
-#'   \item{cv_arrival}{Numeric. Coefficient of variation in time between
+#'   \item{cv_arrival}{Numeric. Coefficient of variation in the time between
 #'     additions to the waiting list.}
-#'   \item{cv_removal}{Numeric. Coefficient of variation in time between
+#'   \item{cv_removal}{Numeric. Coefficient of variation in the time between
 #'     removals from the waiting list.}
-#'   \item{target_capacity}{Numeric. The weekly capacity required to maintain
-#'     the waiting list at its target equilibrium, assuming the target queue
-#'       size has been reached.}
-#'   \item{relief_capacity}{Numeric. If \code{queue_too_big} is \code{TRUE},
-#'     the weekly capacity required to reduce the queue to the target size in
-#'     26 weeks. Otherwise \code{NA}.}
+#'   \item{target_capacity}{Numeric. The weekly treatment capacity required to
+#'     maintain the waiting list at its target equilibrium, assuming the target
+#'     queue size has been reached.}
+#'   \item{relief_capacity}{Numeric. The temporary weekly capacity required to
+#'     reduce the waiting list to its \code{target_queue_size} within 26 weeks,
+#'     assuming current demand remains steady. Calculated only if
+#'     \code{queue_too_big} is \code{TRUE}; otherwise returns \code{NA}.}
 #'   \item{pressure}{Numeric. A measure of pressure on the system, defined as
-#'     \code{2 × mean_wait / target_wait}.}
+#'     \code{2 × mean_wait / target_wait}. Values greater than 1 suggest the
+#'     system is unlikely to meet its waiting time targets.}
 #' }
 #'
 #' @export

--- a/R/wl_stats.R
+++ b/R/wl_stats.R
@@ -16,8 +16,8 @@
 #'   \item{mean_capacity}{Numeric. Mean number of removals from the waiting list
 #'     per week.}
 #'   \item{load}{Numeric. Ratio between demand and capacity.}
-#'   \item{load_too_big}{Logical. Whether the load is greater than or equal to 1,
-#'     indicating whether the waiting list is unstable and expected to grow.}
+#'   \item{load_too_big}{Logical. Whether the load is greater than or equal to
+#'     1, indicating whether the waiting list is unstable and expected to grow.}
 #'   \item{count_demand}{Numeric. Total demand (i.e., number of referrals) over
 #'     the full time period.}
 #'   \item{queue_size}{Numeric. Number of patients on the waiting list at the

--- a/man/create_waiting_list.Rd
+++ b/man/create_waiting_list.Rd
@@ -39,8 +39,23 @@ as ROTT. Defaults to 0.}
 \item{...}{Container for the list}
 }
 \value{
-A tibble of a random generated list of patients with addition_date,
-removal_date, wait_length and rott status for each patient
+A tibble with randomly generated patient records and the following
+columns:
+
+\describe{
+\item{pat_id}{Integer. Unique identifier for the patient.}
+\item{addition_date}{Date. The date the patient was added to the waiting
+list.}
+\item{removal_date}{Date. The date the patient was removed from the
+waiting list.}
+\item{wait_length}{Numeric. Number of days between the addition and
+removal dates.}
+\item{rott}{Logical. Whether the removal was for
+reasons other than treatment (ROTT).}
+}
+Additional columns may be included if supplied via \code{...},
+where named vectors (e.g., patient-level variables) of compatible length
+are merged into the output tibble.
 }
 \description{
 Creates a waiting list using the parameters specified

--- a/man/sim_patients.Rd
+++ b/man/sim_patients.Rd
@@ -17,25 +17,24 @@ A data.frame representing an empty waiting list with the following columns:
 \describe{
 \item{Referral}{Logical. Referral date; all values are \code{NA}.}
 \item{Removal}{Date. Removal date; all values are \code{NA}.}
-\item{Withdrawal}{Logical. Indicates if the patient withdrew before
-treatment; all values are \code{NA}.}
-\item{Priority}{Numeric. Generated Waiting list priority level,
-from 1 (most urgent) to 4 (least urgent).}
-\item{Target_wait}{Numeric. Target number of days the patient should wait
-at the assigned priority level e.g. 28 at priority 2.}
-\item{Name}{Character. Randomly generated patient name in the format
+\item{Withdrawal}{Logical. Patient withdrawal date; all values are
+\code{NA}}
+\item{Priority}{Numeric. Waiting list priority level, from 1
+(most urgent) to 4 (least urgent).}
+\item{Target_wait}{Numeric. Target number of days the patient should
+wait at the assigned priority level (e.g., 28 days for priority 2)}
+\item{Name}{Character. Patient name in the format
 \code{"Last, First"}.}
-\item{Birth_Date}{Date. Generated patient date of birth, using a
-semi-realistic age distribution.}
-\item{NHS_number}{Integer. Generated patient number up to 1,000,000.}
-\item{Specialty_code}{Character. One-digit code for the specialty of the
-selected procedure.}
-\item{Specialty}{Character. Name of the specialty for the selected
-procedure.}
-\item{OPCS}{Character. OPCS-4 code of the randomly selected procedure.}
-\item{Proceedure}{Character. Name of the randomly selected procedure.}
-\item{Consultant}{Character. Randomly generated consultant name in the
-format \code{"Last, First"}.}
+\item{Birth_Date}{Date. Date of birth.}
+\item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
+\item{Specialty_code}{Character. One-letter code representing the
+specialty of the procedure.}
+\item{Specialty}{Character. Full name of the specialty associated with
+the procedure.}
+\item{OPCS}{Character. OPCS-4 code of the selected procedure.}
+\item{Proceedure}{Character. Name of the selected procedure.}
+\item{Consultant}{Character. Consultant name in the format
+\code{"Last, First"}.}
 }
 }
 \description{

--- a/man/sim_patients.Rd
+++ b/man/sim_patients.Rd
@@ -12,7 +12,8 @@ sim_patients(n_rows = 10, start_date = NULL)
 \item{start_date}{Start date (needed to generate patient ages)}
 }
 \value{
-A data.frame representing an empty waiting list with the following columns:
+A data.frame representing an empty waiting list with the
+following columns:
 
 \describe{
 \item{Referral}{Logical. Referral date; all values are \code{NA}.}

--- a/man/sim_patients.Rd
+++ b/man/sim_patients.Rd
@@ -12,7 +12,31 @@ sim_patients(n_rows = 10, start_date = NULL)
 \item{start_date}{Start date (needed to generate patient ages)}
 }
 \value{
-data.frame. Empty waiting list.
+A data.frame representing an empty waiting list with the following columns:
+
+\describe{
+\item{Referral}{Logical. Referral date; all values are \code{NA}.}
+\item{Removal}{Date. Removal date; all values are \code{NA}.}
+\item{Withdrawal}{Logical. Indicates if the patient withdrew before
+treatment; all values are \code{NA}.}
+\item{Priority}{Numeric. Generated Waiting list priority level,
+from 1 (most urgent) to 4 (least urgent).}
+\item{Target_wait}{Numeric. Target number of days the patient should wait
+at the assigned priority level e.g. 28 at priority 2.}
+\item{Name}{Character. Randomly generated patient name in the format
+\code{"Last, First"}.}
+\item{Birth_Date}{Date. Generated patient date of birth, using a
+semi-realistic age distribution.}
+\item{NHS_number}{Integer. Generated patient number up to 1,000,000.}
+\item{Specialty_code}{Character. One-digit code for the specialty of the
+selected procedure.}
+\item{Specialty}{Character. Name of the specialty for the selected
+procedure.}
+\item{OPCS}{Character. OPCS-4 code of the randomly selected procedure.}
+\item{Proceedure}{Character. Name of the randomly selected procedure.}
+\item{Consultant}{Character. Randomly generated consultant name in the
+format \code{"Last, First"}.}
+}
 }
 \description{
 Generates simulated NHS patients

--- a/man/sim_schedule.Rd
+++ b/man/sim_schedule.Rd
@@ -14,7 +14,9 @@ sim_schedule(n_rows = 10, start_date = NULL, daily_capacity = 1)
 \item{daily_capacity}{Number of patients per day}
 }
 \value{
-data.frame. Empty waiting list.
+A vector of \code{Date} values representing scheduled procedure
+dates. The length of the vector is equal to \code{n_rows}, and the dates
+are spaced according to the specified \code{daily_capacity}.
 }
 \description{
 Generates a list if dates in a given range

--- a/man/wl_insert.Rd
+++ b/man/wl_insert.Rd
@@ -16,7 +16,15 @@ waiting list}
 contains the referral dates}
 }
 \value{
-dataframe. A df of the updated waiting list
+A \code{data.frame} representing the updated waiting list
+with additional referrals dates, with columns:
+
+\describe{
+\item{referral}{Date. The updated referral dates, with new values from
+\code{additions} appended to the existing data.}
+\item{removal}{Date. The removal date for each patient. Newly added
+rows have \code{NA} in this column.}
+}
 }
 \description{
 adds new referrals (removal date is set as NA)

--- a/man/wl_join.Rd
+++ b/man/wl_join.Rd
@@ -14,7 +14,10 @@ wl_join(wl_1, wl_2, referral_index = 1)
 \item{referral_index}{the column index where referrals are listed}
 }
 \value{
-updated_list a new waiting list
+A data.frame representing the combined waiting list, created by
+joining \code{wl_1} and \code{wl_2}. The result is sorted by the referral
+date column specified by \code{referral_index}. The column structure is
+preserved from the input data frames.
 }
 \description{
 Take two waiting list and sorting in date order

--- a/man/wl_queue_size.Rd
+++ b/man/wl_queue_size.Rd
@@ -24,7 +24,15 @@ wl_queue_size(
 \item{removal_index}{the index of removals in waiting_list}
 }
 \value{
-a list of dates and queue sizes
+A data.frame containing the size of the waiting list for each day in
+the specified date range. If \code{start_date} and/or \code{end_date} are
+\code{NULL}, the function uses the earliest and latest referral dates in
+the input data.frame. The returned data.frame has the following columns:
+
+\describe{
+\item{dates}{Date. Each date within the computed range, starting from the first referral.}
+\item{queue_size}{Numeric. Number of patients on the waiting list on that date.}
+}
 }
 \description{
 Calculates queue sizes from a waiting list

--- a/man/wl_queue_size.Rd
+++ b/man/wl_queue_size.Rd
@@ -30,8 +30,10 @@ the specified date range. If \code{start_date} and/or \code{end_date} are
 the input data.frame. The returned data.frame has the following columns:
 
 \describe{
-\item{dates}{Date. Each date within the computed range, starting from the first referral.}
-\item{queue_size}{Numeric. Number of patients on the waiting list on that date.}
+\item{dates}{Date. Each date within the computed range, starting from the
+first referral.}
+\item{queue_size}{Numeric. Number of patients on the waiting list
+on that date.}
 }
 }
 \description{

--- a/man/wl_referral_stats.Rd
+++ b/man/wl_referral_stats.Rd
@@ -25,9 +25,12 @@ A data.frame with the following summary statistics on
 referrals/demand:
 
 \describe{
-\item{demand_weekly}{Numeric. Mean number of additions to the waiting list per week.}
-\item{demand_daily}{Numeric. Mean number of additions to the waiting list per day.}
-\item{demand_cov}{Numeric. Coefficient of variation in the time between additions to the waiting list.}
+\item{demand_weekly}{Numeric. Mean number of additions to the waiting list
+per week.}
+\item{demand_daily}{Numeric. Mean number of additions to the waiting list
+per day.}
+\item{demand_cov}{Numeric. Coefficient of variation in the time between
+additions to the waiting list.}
 \item{demand_count}{Numeric. Total demand over the full time period.}
 }
 }

--- a/man/wl_referral_stats.Rd
+++ b/man/wl_referral_stats.Rd
@@ -21,8 +21,15 @@ wl_referral_stats(
 \item{referral_index}{the column index of referrals}
 }
 \value{
-data.frame. A df containing number of referrals, mean demand,
-and the coefficient of variation of referrals
+A data.frame with the following summary statistics on
+referrals/demand:
+
+\describe{
+\item{demand_weekly}{Numeric. Mean number of additions to the waiting list per week.}
+\item{demand_daily}{Numeric. Mean number of additions to the waiting list per day.}
+\item{demand_cov}{Numeric. Coefficient of variation in the time between additions to the waiting list.}
+\item{demand_count}{Numeric. Total demand over the full time period.}
+}
 }
 \description{
 Calculate some stats about referrals

--- a/man/wl_removal_stats.Rd
+++ b/man/wl_removal_stats.Rd
@@ -24,8 +24,15 @@ wl_removal_stats(
 \item{removal_index}{int. Index of the removal column in waiting_list.}
 }
 \value{
-data.frame. A df containing number of removals, mean capacity,
-and the coefficient of variation of removals
+A data.frame with the following summary statistics on
+removals/capacity:
+
+\describe{
+\item{capacity_weekly}{Numeric. Mean number of removals from the waiting list per week.}
+\item{capacity_daily}{Numeric. Mean number of removals from the waiting list per day.}
+\item{capacity_cov}{Numeric. Coefficient of variation in the time between removals from the waiting list.}
+\item{removal_count}{Numeric. Total number of removals from the waiting list over the full time period.}
+}
 }
 \description{
 Calculate some stats about removals

--- a/man/wl_removal_stats.Rd
+++ b/man/wl_removal_stats.Rd
@@ -28,10 +28,14 @@ A data.frame with the following summary statistics on
 removals/capacity:
 
 \describe{
-\item{capacity_weekly}{Numeric. Mean number of removals from the waiting list per week.}
-\item{capacity_daily}{Numeric. Mean number of removals from the waiting list per day.}
-\item{capacity_cov}{Numeric. Coefficient of variation in the time between removals from the waiting list.}
-\item{removal_count}{Numeric. Total number of removals from the waiting list over the full time period.}
+\item{capacity_weekly}{Numeric. Mean number of removals from the waiting
+list per week.}
+\item{capacity_daily}{Numeric. Mean number of removals from the waiting
+list per day.}
+\item{capacity_cov}{Numeric. Coefficient of variation in the time between
+removals from the waiting list.}
+\item{removal_count}{Numeric. Total number of removals from the waiting
+list over the full time period.}
 }
 }
 \description{

--- a/man/wl_schedule.Rd
+++ b/man/wl_schedule.Rd
@@ -30,8 +30,22 @@ If TRUE, returns a list of scheduled and unscheduled procedures
 If FALSE, only returns the updated waiting list}
 }
 \value{
-data.frame. A df of the updated waiting list with removal dates
-added according to the schedule
+The updated waiting list with removal dates assigned based on
+the given schedule, either as a single \code{data.frame} (default) or as
+part of a list (if \code{unscheduled = TRUE}).
+
+If \code{unscheduled = TRUE}, returns a \code{list} with two data frames:
+\enumerate{
+\item A \code{data.frame}. The updated waiting list with scheduled removals.
+\item A \code{data.frame} showing which slots were used, with columns:
+
+\describe{
+\item{schedule}{Date. The available dates from the input
+\code{schedule}.}
+\item{scheduled}{Numeric. \code{1} if the slot was used to schedule a
+patient, \code{0} if not.}
+}
+}
 }
 \description{
 Takes a list of dates and schedules them to a waiting list,

--- a/man/wl_simulator.Rd
+++ b/man/wl_simulator.Rd
@@ -30,7 +30,38 @@ wl_simulator(
 \item{detailed_sim}{logical. If TRUE, simulation provides detailed output.}
 }
 \value{
-data.frame. A df of simulated referrals and removals
+A \code{data.frame} simulating a waiting list, with columns:
+
+\describe{
+\item{Referral}{Date. The date each patient was added to the waiting list.}
+\item{Removal}{Date. The date each patient was removed from the waiting
+list (may be \code{NA} if unscheduled).}
+
+\strong{If \code{detailed_sim = TRUE}}: returns a more detailed
+\code{data.frame} with the following additional
+fields:
+
+\describe{
+\item{Withdrawal}{Date. The date the patient withdrew from the
+waiting list.}
+\item{Priority}{Numeric. Waiting list priority level, from 1
+(most urgent) to 4 (least urgent).}
+\item{Target_wait}{Numeric. Target number of days the patient should
+wait at the assigned priority level (e.g., 28 days for priority 2)}
+\item{Name}{Character. Patient name in the format
+\code{"Last, First"}.}
+\item{Birth_Date}{Date. Date of birth.}
+\item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
+\item{Specialty_code}{Character. One-letter code representing the
+specialty of the procedure.}
+\item{Specialty}{Character. Full name of the specialty associated with
+the procedure.}
+\item{OPCS}{Character. OPCS-4 code of the selected procedure.}
+\item{Proceedure}{Character. Name of the selected procedure.}
+\item{Consultant}{Character. Consultant name in the format
+\code{"Last, First"}.}
+}
+}
 }
 \description{
 Creates a simulated waiting list comprising referral dates,

--- a/man/wl_stats.Rd
+++ b/man/wl_stats.Rd
@@ -25,8 +25,8 @@ per week.}
 \item{mean_capacity}{Numeric. Mean number of removals from the waiting list
 per week.}
 \item{load}{Numeric. Ratio between demand and capacity.}
-\item{load_too_big}{Logical. Whether the load is greater than or equal to 1,
-indicating whether the waiting list is unstable and expected to grow.}
+\item{load_too_big}{Logical. Whether the load is greater than or equal to
+1, indicating whether the waiting list is unstable and expected to grow.}
 \item{count_demand}{Numeric. Total demand (i.e., number of referrals) over
 the full time period.}
 \item{queue_size}{Numeric. Number of patients on the waiting list at the

--- a/man/wl_stats.Rd
+++ b/man/wl_stats.Rd
@@ -16,7 +16,39 @@ wl_stats(waiting_list, target_wait = 4, start_date = NULL, end_date = NULL)
 \item{end_date}{date. The end date to calculate to}
 }
 \value{
-data.frame. A df of important waiting list statistics
+A data.frame of key waiting list summary statistics based on queueing
+theory:
+
+\describe{
+\item{mean_demand}{Numeric. Mean number of additions to the waiting list
+per week.}
+\item{mean_capacity}{Numeric. Mean number of removals from the waiting list
+per week.}
+\item{load}{Numeric. Ratio between demand and capacity.}
+\item{load_too_big}{Logical. Whether the load is greater than or equal to 1
+i.e. whether the waiting list is unstable and expected to grow.}
+\item{count_demand}{Numeric. Total demand (i.e. referrals) over the full
+time period.}
+\item{queue_size}{Numeric. Number of patients on the waiting list at the
+end of the time period.}
+\item{target_queue_size}{Numeric. Size of waiting list required for the
+average wait time to be a quarter of the \code{target_wait}.}
+\item{queue_too_big}{Logical. Whether \code{queue_size} is more than twice
+the \code{target_queue_size}.}
+\item{mean_wait}{Numeric. Mean waiting time in weeks.}
+\item{cv_arrival}{Numeric. Coefficient of variation in time between
+additions to the waiting list.}
+\item{cv_removal}{Numeric. Coefficient of variation in time between
+removals from the waiting list.}
+\item{target_capacity}{Numeric. The weekly capacity required to maintain
+the waiting list at its target equilibrium, assuming the target queue
+size has been reached.}
+\item{relief_capacity}{Numeric. If \code{queue_too_big} is \code{TRUE},
+the weekly capacity required to reduce the queue to the target size in
+26 weeks. Otherwise \code{NA}.}
+\item{pressure}{Numeric. A measure of pressure on the system, defined as
+\code{2 × mean_wait / target_wait}.}
+}
 }
 \description{
 A summary of all the key stats associated with a waiting list

--- a/man/wl_stats.Rd
+++ b/man/wl_stats.Rd
@@ -16,8 +16,8 @@ wl_stats(waiting_list, target_wait = 4, start_date = NULL, end_date = NULL)
 \item{end_date}{date. The end date to calculate to}
 }
 \value{
-A data.frame of key waiting list summary statistics based on queueing
-theory:
+A data.frame of key waiting list summary statistics based on
+queueing theory:
 
 \describe{
 \item{mean_demand}{Numeric. Mean number of additions to the waiting list
@@ -25,29 +25,35 @@ per week.}
 \item{mean_capacity}{Numeric. Mean number of removals from the waiting list
 per week.}
 \item{load}{Numeric. Ratio between demand and capacity.}
-\item{load_too_big}{Logical. Whether the load is greater than or equal to 1
-i.e. whether the waiting list is unstable and expected to grow.}
-\item{count_demand}{Numeric. Total demand (i.e. referrals) over the full
-time period.}
+\item{load_too_big}{Logical. Whether the load is greater than or equal to 1,
+indicating whether the waiting list is unstable and expected to grow.}
+\item{count_demand}{Numeric. Total demand (i.e., number of referrals) over
+the full time period.}
 \item{queue_size}{Numeric. Number of patients on the waiting list at the
 end of the time period.}
-\item{target_queue_size}{Numeric. Size of waiting list required for the
-average wait time to be a quarter of the \code{target_wait}.}
+\item{target_queue_size}{Numeric. The recommended size of the waiting list
+to achieve approximately 98.2\% of patients being treated within their
+target wait time. This is based on Little’s Law, assuming the system
+is in equilibrium, with the average waiting time set to one-quarter of
+the \code{target_wait}.}
 \item{queue_too_big}{Logical. Whether \code{queue_size} is more than twice
-the \code{target_queue_size}.}
+the \code{target_queue_size}. A value of \code{TRUE} indicates the queue
+is at risk of missing its targets.}
 \item{mean_wait}{Numeric. Mean waiting time in weeks.}
-\item{cv_arrival}{Numeric. Coefficient of variation in time between
+\item{cv_arrival}{Numeric. Coefficient of variation in the time between
 additions to the waiting list.}
-\item{cv_removal}{Numeric. Coefficient of variation in time between
+\item{cv_removal}{Numeric. Coefficient of variation in the time between
 removals from the waiting list.}
-\item{target_capacity}{Numeric. The weekly capacity required to maintain
-the waiting list at its target equilibrium, assuming the target queue
-size has been reached.}
-\item{relief_capacity}{Numeric. If \code{queue_too_big} is \code{TRUE},
-the weekly capacity required to reduce the queue to the target size in
-26 weeks. Otherwise \code{NA}.}
+\item{target_capacity}{Numeric. The weekly treatment capacity required to
+maintain the waiting list at its target equilibrium, assuming the target
+queue size has been reached.}
+\item{relief_capacity}{Numeric. The temporary weekly capacity required to
+reduce the waiting list to its \code{target_queue_size} within 26 weeks,
+assuming current demand remains steady. Calculated only if
+\code{queue_too_big} is \code{TRUE}; otherwise returns \code{NA}.}
 \item{pressure}{Numeric. A measure of pressure on the system, defined as
-\code{2 × mean_wait / target_wait}.}
+\code{2 × mean_wait / target_wait}. Values greater than 1 suggest the
+system is unlikely to meet its waiting time targets.}
 }
 }
 \description{


### PR DESCRIPTION
Added more detailed `@return` value descriptions including column-level specifications for functions that return `data.frame` outputs. Let me know if any descriptions could be improved or clarified.

Closes #108 

**Added column specification - column names, data types, and a short description:**
- `wl_referral_stats()`
- `wl_removal_stats()`
- `wl_stats()`
- `create_waiting_list()`
- `wl_queue_size()`
- `sim_patients()`
- `wl_simulator()`
- `wl_insert()`

**Replaced or expanded return value documentation for:**
- `wl_join()`
- `wl_schedule()` - including description of conditionally output list.
- `sim_schedule()` - not a data frame, but previously re-used return from `sim_patients()`

**Notes (potential separate issues):**
- `sim_patients()` and therefore wl_simulator() output column name of "Proceedure" with 2 "e"s. 
- `sim_patients()` columns `Referral` and `Withdrawal` are type `logical`. This causes no issues with its use in `wl_simulator()`, but stands out because the `Removal` column has been explictly defined as `Date`.
- `sim_patients()` output has inconsistent capitalisation betwen column `Birth_Date` and other fields.
- `wl_insert()` argument `referral_index` is only used to select which column to order by; input columns must be called `referral` and `removal` for the function to work.

I have documented these as-is.