### PR TITLE
Tidy up `sim_patients()` output

### DIFF
--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -26,7 +26,7 @@
 #'   \item{Specialty}{Character. Full name of the specialty associated with
 #'     the procedure.}
 #'   \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
-#'   \item{Proceedure}{Character. Name of the selected procedure.}
+#'   \item{Procedure}{Character. Name of the selected procedure.}
 #'   \item{Consultant}{Character. Consultant name in the format
 #'     \code{"Last, First"}.}
 #'  }
@@ -49,7 +49,7 @@ sim_patients <- function(
   # get procedures
   ops <- opcs4[(opcs4$selectable == "Y") & (!is.na(opcs4$name_4digit)), ]
   ran <- ops[sample(nrow(ops), n_rows, replace = TRUE), ]
-  proceedures <-
+  procedures <-
     ran[c("code_1digit", "name_1digit", "code_4digit", "name_4digit")]
 
   # get names consultants and NHS numbers (length actually too short)
@@ -90,10 +90,10 @@ sim_patients <- function(
     Name = names,
     Birth_Date = dobs,
     NHS_number = nhs_number,
-    Specialty_code = proceedures$code_1digit,
-    Specialty = proceedures$name_1digit,
-    OPCS = proceedures$code_4digit,
-    Proceedure = proceedures$name_4digit,
+    Specialty_code = procedures$code_1digit,
+    Specialty = procedures$name_1digit,
+    OPCS = procedures$code_4digit,
+    Procedure = procedures$name_4digit,
     Consultant = consultant
   )
 

--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -19,7 +19,7 @@
 #'     wait at the assigned priority level (e.g., 28 days for priority 2)}
 #'   \item{Name}{Character. Patient name in the format
 #'     \code{"Last, First"}.}
-#'   \item{Birth_Date}{Date. Date of birth.}
+#'   \item{Birth_date}{Date. Date of birth.}
 #'   \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
 #'   \item{Specialty_code}{Character. One-letter code representing the
 #'     specialty of the procedure.}
@@ -88,7 +88,7 @@ sim_patients <- function(
     Priority = priority,
     Target_wait = target_wait,
     Name = names,
-    Birth_Date = dobs,
+    Birth_date = dobs,
     NHS_number = nhs_number,
     Specialty_code = procedures$code_1digit,
     Specialty = procedures$name_1digit,

--- a/R/sim_patients.R
+++ b/R/sim_patients.R
@@ -9,9 +9,9 @@
 #'  following columns:
 #'
 #' \describe{
-#'   \item{Referral}{Logical. Referral date; all values are \code{NA}.}
+#'   \item{Referral}{Date. Referral date; all values are \code{NA}.}
 #'   \item{Removal}{Date. Removal date; all values are \code{NA}.}
-#'   \item{Withdrawal}{Logical. Patient withdrawal date; all values are
+#'   \item{Withdrawal}{Date. Patient withdrawal date; all values are
 #'     \code{NA}}
 #'   \item{Priority}{Numeric. Waiting list priority level, from 1
 #'     (most urgent) to 4 (least urgent).}
@@ -77,14 +77,12 @@ sim_patients <- function(
   target_wait <- sapply(priority, calc_priority_to_target)
 
   # referral, removal, withdrawal columns
-  referral <- c(rep(NA, n_rows))
-  removal <- as.Date(c(rep(NA, n_rows)))
-  withdrawal <- c(rep(NA, n_rows))
+  empty_date_vector <- as.Date(rep(NA, n_rows))
 
   waiting_list <- data.frame(
-    Referral = referral,
-    Removal = removal,
-    Withdrawal = withdrawal,
+    Referral = empty_date_vector,
+    Removal = empty_date_vector,
+    Withdrawal = empty_date_vector,
     Priority = priority,
     Target_wait = target_wait,
     Name = names,

--- a/R/wl_simulator.R
+++ b/R/wl_simulator.R
@@ -19,30 +19,28 @@
 #'     list (may be \code{NA} if unscheduled).}
 #'
 #'
-#'   \strong{If \code{detailed_sim = TRUE}}: returns a more detailed
+#'   \strong{If \code{detailed_sim = TRUE}}, returns a more detailed
 #'   \code{data.frame} with the following additional
 #'   fields:
 #'
-#'   \describe{
-#'       \item{Withdrawal}{Date. The date the patient withdrew from the
-#'         waiting list.}
-#'       \item{Priority}{Numeric. Waiting list priority level, from 1
-#'         (most urgent) to 4 (least urgent).}
-#'       \item{Target_wait}{Numeric. Target number of days the patient should
-#'         wait at the assigned priority level (e.g., 28 days for priority 2)}
-#'       \item{Name}{Character. Patient name in the format
-#'         \code{"Last, First"}.}
-#'       \item{Birth_Date}{Date. Date of birth.}
-#'       \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
-#'       \item{Specialty_code}{Character. One-letter code representing the
-#'         specialty of the procedure.}
-#'       \item{Specialty}{Character. Full name of the specialty associated with
-#'         the procedure.}
-#'       \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
-#'       \item{Proceedure}{Character. Name of the selected procedure.}
-#'       \item{Consultant}{Character. Consultant name in the format
-#'         \code{"Last, First"}.}
-#'   }
+#'   \item{Withdrawal}{Date. The date the patient withdrew from the
+#'     waiting list.}
+#'   \item{Priority}{Numeric. Waiting list priority level, from 1
+#'     (most urgent) to 4 (least urgent).}
+#'   \item{Target_wait}{Numeric. Target number of days the patient should
+#'     wait at the assigned priority level (e.g., 28 days for priority 2)}
+#'   \item{Name}{Character. Patient name in the format
+#'     \code{"Last, First"}.}
+#'   \item{Birth_date}{Date. Date of birth.}
+#'   \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
+#'   \item{Specialty_code}{Character. One-letter code representing the
+#'     specialty of the procedure.}
+#'   \item{Specialty}{Character. Full name of the specialty associated with
+#'     the procedure.}
+#'   \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
+#'   \item{Procedure}{Character. Name of the selected procedure.}
+#'   \item{Consultant}{Character. Consultant name in the format
+#'     \code{"Last, First"}.}
 #' }
 #'
 #' @import dplyr

--- a/man/sim_patients.Rd
+++ b/man/sim_patients.Rd
@@ -16,9 +16,9 @@ A data.frame representing an empty waiting list with the
 following columns:
 
 \describe{
-\item{Referral}{Logical. Referral date; all values are \code{NA}.}
+\item{Referral}{Date. Referral date; all values are \code{NA}.}
 \item{Removal}{Date. Removal date; all values are \code{NA}.}
-\item{Withdrawal}{Logical. Patient withdrawal date; all values are
+\item{Withdrawal}{Date. Patient withdrawal date; all values are
 \code{NA}}
 \item{Priority}{Numeric. Waiting list priority level, from 1
 (most urgent) to 4 (least urgent).}
@@ -26,14 +26,14 @@ following columns:
 wait at the assigned priority level (e.g., 28 days for priority 2)}
 \item{Name}{Character. Patient name in the format
 \code{"Last, First"}.}
-\item{Birth_Date}{Date. Date of birth.}
+\item{Birth_date}{Date. Date of birth.}
 \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
 \item{Specialty_code}{Character. One-letter code representing the
 specialty of the procedure.}
 \item{Specialty}{Character. Full name of the specialty associated with
 the procedure.}
 \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
-\item{Proceedure}{Character. Name of the selected procedure.}
+\item{Procedure}{Character. Name of the selected procedure.}
 \item{Consultant}{Character. Consultant name in the format
 \code{"Last, First"}.}
 }

--- a/man/wl_simulator.Rd
+++ b/man/wl_simulator.Rd
@@ -37,11 +37,10 @@ A \code{data.frame} simulating a waiting list, with columns:
 \item{Removal}{Date. The date each patient was removed from the waiting
 list (may be \code{NA} if unscheduled).}
 
-\strong{If \code{detailed_sim = TRUE}}: returns a more detailed
+\strong{If \code{detailed_sim = TRUE}}, returns a more detailed
 \code{data.frame} with the following additional
 fields:
 
-\describe{
 \item{Withdrawal}{Date. The date the patient withdrew from the
 waiting list.}
 \item{Priority}{Numeric. Waiting list priority level, from 1
@@ -50,17 +49,16 @@ waiting list.}
 wait at the assigned priority level (e.g., 28 days for priority 2)}
 \item{Name}{Character. Patient name in the format
 \code{"Last, First"}.}
-\item{Birth_Date}{Date. Date of birth.}
+\item{Birth_date}{Date. Date of birth.}
 \item{NHS_number}{Integer. Patient identifier, up to 100,000,000.}
 \item{Specialty_code}{Character. One-letter code representing the
 specialty of the procedure.}
 \item{Specialty}{Character. Full name of the specialty associated with
 the procedure.}
 \item{OPCS}{Character. OPCS-4 code of the selected procedure.}
-\item{Proceedure}{Character. Name of the selected procedure.}
+\item{Procedure}{Character. Name of the selected procedure.}
 \item{Consultant}{Character. Consultant name in the format
 \code{"Last, First"}.}
-}
 }
 }
 \description{

--- a/tests/testthat/test-sim_patients.R
+++ b/tests/testthat/test-sim_patients.R
@@ -9,7 +9,7 @@ test_that("sim_patients returns the correct columns", {
   result <- sim_patients(n_rows = 10)
   expected_columns <- c("Referral", "Removal", "Withdrawal", "Priority"
                         , "Target_wait", "Name",
-                        "Birth_Date", "NHS_number", "Specialty_code",
+                        "Birth_date", "NHS_number", "Specialty_code",
                         "Specialty", "OPCS",
                         "Procedure", "Consultant")
   expect_true(all(expected_columns %in% colnames(result)))
@@ -18,7 +18,7 @@ test_that("sim_patients returns the correct columns", {
 # Test for handling missing start_date (default to current date)
 test_that("sim_patients handles missing start_date by using Sys.Date()", {
   result <- sim_patients(n_rows = 5)
-  expect_s3_class(result$Birth_Date, "Date")  # Check if birth_date is assigned
+  expect_s3_class(result$Birth_date, "Date")  # Check if birth_date is assigned
 })
 
 # Test if priority values are within the expected range (1-4)

--- a/tests/testthat/test-sim_patients.R
+++ b/tests/testthat/test-sim_patients.R
@@ -11,7 +11,7 @@ test_that("sim_patients returns the correct columns", {
                         , "Target_wait", "Name",
                         "Birth_Date", "NHS_number", "Specialty_code",
                         "Specialty", "OPCS",
-                        "Proceedure", "Consultant")
+                        "Procedure", "Consultant")
   expect_true(all(expected_columns %in% colnames(result)))
 })
 


### PR DESCRIPTION
- Rename column `Proceedure` to `Procedure`.
- Rename column `Birth_Date` to `Birth_date`.
- Set columns `Referral` and `Withdrawal` as date.
- Reflect updates in documentation for `sim_patients()` and `wl_simulator()`.

I noticed the `wl_simulator()` detailed_sim column section introduced in #109 was rendering correctly in the RStudio Help viewer, but not the pkgdown site. I removed a nested `\description{}` tag to fix.

Closes #110 