### PR TITLE
Fixes to `wl_insert()` structure and `referral_index` usage

### DIFF
--- a/R/wl_insert.R
+++ b/R/wl_insert.R
@@ -1,22 +1,18 @@
 #' @title Insert new referrals into the waiting list
 #'
-#' @description adds new referrals (removal date is set as NA)
+#' @description Adds new referrals, with other columns set as \code{NA}.
 #'
-#' @param waiting_list dataframe. A df of referral dates and removals
-#' @param additions character vector. A list of referral dates to add to the
-#'   waiting list
-#' @param referral_index integer. The column number in the waiting_list which
-#'   contains the referral dates
+#' @param waiting_list data.frame. A df of referral dates and removals
+#' @param additions Character or Date vector. A list of referral dates to add to
+#'   the waiting list
+#' @param referral_index The index of the column in \code{waiting_list} which
+#'   contains the referral dates. Defaults to the first column.
 #'
-#' @return A \code{data.frame} representing the updated waiting list
-#'   with additional referrals dates, with columns:
+#' @return A \code{data.frame} representing the updated waiting list,
+#'   with additional referrals dates in the column specified by
+#'   \code{referral_index}. Other columns are filled with \code{NA} in the
+#'   new rows. The result is sorted by the referral column.
 #'
-#' \describe{
-#'   \item{referral}{Date. The updated referral dates, with new values from
-#'     \code{additions} appended to the existing data.}
-#'   \item{removal}{Date. The removal date for each patient. Newly added
-#'     rows have \code{NA} in this column.}
-#' }
 #' @export
 #'
 #' @examples

--- a/R/wl_insert.R
+++ b/R/wl_insert.R
@@ -27,10 +27,11 @@
 #' longer_waiting_list <- wl_insert(waiting_list, additions)
 #'
 wl_insert <- function(waiting_list, additions, referral_index = 1) {
-  new_rows <- data.frame(
-    "referral" = additions,
-    "removal" = rep(as.Date(NA), length(additions))
-  )
+  # keep waiting_list structure and fill with NAs
+  new_rows <- waiting_list[0, ]
+  new_rows[seq_along(additions), ] <- NA
+
+  new_rows[referral_index] <- additions
 
   # recombine to update list
   updated_list <- rbind(waiting_list, new_rows)

--- a/man/wl_insert.Rd
+++ b/man/wl_insert.Rd
@@ -7,27 +7,22 @@
 wl_insert(waiting_list, additions, referral_index = 1)
 }
 \arguments{
-\item{waiting_list}{dataframe. A df of referral dates and removals}
+\item{waiting_list}{data.frame. A df of referral dates and removals}
 
-\item{additions}{character vector. A list of referral dates to add to the
-waiting list}
+\item{additions}{Character or Date vector. A list of referral dates to add to
+the waiting list}
 
-\item{referral_index}{integer. The column number in the waiting_list which
-contains the referral dates}
+\item{referral_index}{The index of the column in \code{waiting_list} which
+contains the referral dates. Defaults to the first column.}
 }
 \value{
-A \code{data.frame} representing the updated waiting list
-with additional referrals dates, with columns:
-
-\describe{
-\item{referral}{Date. The updated referral dates, with new values from
-\code{additions} appended to the existing data.}
-\item{removal}{Date. The removal date for each patient. Newly added
-rows have \code{NA} in this column.}
-}
+A \code{data.frame} representing the updated waiting list,
+with additional referrals dates in the column specified by
+\code{referral_index}. Other columns are filled with \code{NA} in the
+new rows. The result is sorted by the referral column.
 }
 \description{
-adds new referrals (removal date is set as NA)
+Adds new referrals, with other columns set as \code{NA}.
 }
 \examples{
 referrals <- c.Date("2024-01-01", "2024-01-04", "2024-01-10", "2024-01-16")

--- a/tests/testthat/test-wl_insert.R
+++ b/tests/testthat/test-wl_insert.R
@@ -43,3 +43,42 @@ test_that("inserting to list returns right output", {
   em <- "wl_insert(): expected result for test data including sorting."
   expect_identical(wl_insert(wl1, additions), expected_out)
 })
+
+test_that("the column receiving additions is defined by the index", {
+  referral_index <- 2
+  other_index <- 1
+
+  test_output <- wl_insert(wl1,
+                           additions,
+                           referral_index = referral_index)
+
+  # no NAs added at chosen index
+  expect_equal(
+    sum(is.na(test_output[[referral_index]])),
+    sum(is.na(wl1[[referral_index]]))
+  )
+
+  # NAs added elsewhere
+  expect_gt(
+    sum(is.na(test_output[[other_index]])),
+    sum(is.na(wl1[[other_index]]))
+  )
+})
+
+test_that("valid indexes of different types work", {
+  # numeric
+  expect_identical(wl_insert(wl1,
+                             additions,
+                             referral_index = 1),
+                   expected_out)
+  # character
+  expect_identical(wl_insert(wl1,
+                             additions,
+                             referral_index = "referral"),
+                   expected_out)
+  # logical
+  expect_identical(wl_insert(wl1,
+                             additions,
+                             referral_index = c(TRUE, FALSE)),
+                   expected_out)
+})


### PR DESCRIPTION
`wl_insert()`
- Now uses the column structure of the input `waiting_list` arg for `new_rows`.
- Additions are now made to the column specified by `referral_index` arg.
- Therefore no longer requires specific column names.

I think this closes #111; I haven't changed `wl_join()`, but the referral_index there is not problematic as such.