### PR TITLE
125 fix minor lint issues

### DIFF
--- a/R/wl_simulator.R
+++ b/R/wl_simulator.R
@@ -66,7 +66,8 @@ wl_simulator <- function(
   # check input type for WL
   if (!is.null(waiting_list)) {
     if (!methods::is(waiting_list, "data.frame")) {
-      stop("Waiting list is not supplied as a data.frame")}
+      stop("Waiting list is not supplied as a data.frame")
+    }
   }
 
 

--- a/tests/testthat/test-wl_simulator.R
+++ b/tests/testthat/test-wl_simulator.R
@@ -38,12 +38,11 @@ test_that("wl_simulator works with detailed_sim = TRUE", {
 # Test for behaviour when `waiting_list` is provided
 test_that("wl_simulator incorporates waiting_list correctly", {
   result1 <- wl_simulator("2024-03-20", "2024-03-31"
-                         , demand = 100, capacity = 110)
+                          , demand = 100, capacity = 110)
 
   result2 <- wl_simulator("2024-04-01", "2024-04-02"
-                         , demand = 100, capacity = 110
-                         , waiting_list = result1
-                         )
+                          , demand = 100, capacity = 110
+                          , waiting_list = result1)
   expect_true(nrow(result2) >= 100)  # Ensure waiting_list is incorporated
 })
 


### PR DESCRIPTION
Just fixing the remaining lintr complaints, hopefully to get the github actions to run through to "green" completion status.
There may still be some trailing line complaints, because git does not by default track changes to files after the last non-whitespace content.  I'll fix this separately if it's still a problem.