### PR TITLE
Fix for R-devel test failures

### DIFF
--- a/R/wl_queue_size.R
+++ b/R/wl_queue_size.R
@@ -56,6 +56,7 @@ wl_queue_size <- function(waiting_list,
 
   wl[wl[, referral_index] < start_date, referral_index] <- start_date
   arrival_counts <- data.frame(table(wl[, referral_index]))
+  arrival_counts[, 1] <- as.Date(arrival_counts[, 1])
 
   dates <- seq(as.Date(start_date), as.Date(end_date), by = "day")
   queues <- data.frame(dates, rep(0, length(dates)))
@@ -72,6 +73,8 @@ wl_queue_size <- function(waiting_list,
         table(wl[which((start_date <= wl[, removal_index]) &
                          (wl[, removal_index] <= end_date)), removal_index])
       )
+
+    departure_counts[, 1] <- as.Date(departure_counts[, 1])
 
     queues$departures <- rep(0, length(dates))
     queues[which(queues[, 1] %in% departure_counts[, 1]), 4] <-

--- a/R/wl_queue_size.R
+++ b/R/wl_queue_size.R
@@ -37,14 +37,6 @@ wl_queue_size <- function(waiting_list,
   check_wl(waiting_list, referral_index, removal_index)
   check_date(start_date, end_date, .allow_null = TRUE)
 
-  if (missing(waiting_list)) {
-    stop("No waiting list supplied")
-  } else {
-    if (nrow(waiting_list) == 0) {
-      stop("No rows in supplied waiting list")
-    }
-  }
-
   wl <- waiting_list
 
   if (is.null(start_date)) {


### PR DESCRIPTION
In `wl_queue_size()` there is/was a `<Date> %in% <factor>` logical check. In the release version (R4.5.x) the factor is silently coerced to `<Date>`, but it isn't in R-devel (for R4.6.0) - the fix is to do the conversion explicitly.

The factors are created by `table()`:

```r
arrival_counts <- data.frame(table(waiting_list[, referral_index]))
```
This first column of the data frame is a factor, so I have just added an explicit conversion:

```r
arrival_counts[, 1] <- as.Date(arrival_counts[, 1])
```
So this becomes`<Date> %in% <Date>`:

```r
queues[which(queues[, 1] %in% arrival_counts[, 1]), 2] <- arrival_counts[, 2]
```
and repeat for departure counts. All being well, this closes #137 - It works on my machine... 🤞🏻

The relevant [R-devel NEWS](https://cran.r-project.org/bin/windows/base/NEWS.R-devel.html) item doesn't describe this change directly, but only talks about `<character>` and `<Date>` working together with a change to `%in%`.

> <Date> %in% set has become as fast again, as it was before R 4.3.0, via new S3 method mtfrm.Date. Additionally, <character> %in% <Date> and vice versa are documented to work in concordance with == and as an exception to the typical match() behaviour which relies on “univariate” mtfrm() alone.